### PR TITLE
fix: remove pygraphviz from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ wandb
 matplotlib
 seaborn
 pydot
-pygraphviz
 
 # PyTorch ecosystem 
 torch


### PR DESCRIPTION
This change simplifies the project's dependencies by removing the unnecessary pygraphviz package from requirements.txt, enhancing clarity and ensuring that only essential libraries are listed.

## Summary by Sourcery

Bug Fixes:
- Remove the unnecessary pygraphviz package from requirements.txt to simplify dependencies.